### PR TITLE
Use server name in pipe file path. 

### DIFF
--- a/easy_motion.tmux
+++ b/easy_motion.tmux
@@ -22,22 +22,27 @@ check_version() {
 }
 
 create_target_key_pipe() {
+    local server_pid
+
+    server_pid="$1"
     # The script can be called without arguments to only create the target pipe
-    "${SCRIPTS_DIR}/pipe_target_key.sh"
+    "${SCRIPTS_DIR}/pipe_target_key.sh" "${server_pid}"
 }
 
 setup_bindings() {
-    local key target_key tmux_key
+    local server_pid key target_key tmux_key
+
+    server_pid="$1"
 
     tmux bind-key "${EASY_MOTION_KEY}" switch-client -T easy-motion
     tmux bind-key -T copy-mode-vi "${EASY_MOTION_KEY}" switch-client -T easy-motion
     while read -N1 key; do
-        tmux bind-key -T easy-motion "${key}" run-shell -b "${SCRIPTS_DIR}/easy_motion.sh '${key}'"
+        tmux bind-key -T easy-motion "${key}" run-shell -b "${SCRIPTS_DIR}/easy_motion.sh '${server_pid}' '${key}'"
     done < <(echo -n "${EASY_MOTION_VALID_SINGLE_MOTION_KEYS}")
     tmux bind-key -T easy-motion "g" switch-client -T easy-motion-g
     tmux bind-key -T easy-motion "Escape" switch-client -T root
     while read -N1 key; do
-        tmux bind-key -T easy-motion-g "${key}" run-shell -b "${SCRIPTS_DIR}/easy_motion.sh 'g${key}'"
+        tmux bind-key -T easy-motion-g "${key}" run-shell -b "${SCRIPTS_DIR}/easy_motion.sh '${server_pid}' 'g${key}'"
     done < <(echo -n "${EASY_MOTION_VALID_SINGLE_MOTION_KEYS_G}")
     tmux bind-key -T easy-motion-g "Escape" switch-client -T root
     while read -N1 key; do
@@ -47,7 +52,7 @@ setup_bindings() {
         tmux source - <<-EOF
 			bind-key -T easy-motion "${key}" command-prompt -1 -p "character:" {
 			    set -g @tmp-easy-motion-argument "%%%"
-			    run-shell -b '${SCRIPTS_DIR}/easy_motion.sh "${key}" "#{q:@tmp-easy-motion-argument}"'
+			    run-shell -b '${SCRIPTS_DIR}/easy_motion.sh "${server_pid}" "${key}" "#{q:@tmp-easy-motion-argument}"'
 			}
 		EOF
     done < <(echo -n "${EASY_MOTION_VALID_MOTION_KEYS_WITH_ARGUMENT}")
@@ -69,16 +74,19 @@ setup_bindings() {
                 ;;
         esac
         # `easy_motion.sh` switches the key table to `easy-motion-target`
-        tmux bind-key -T easy-motion-target "${tmux_key}" run-shell -b "${SCRIPTS_DIR}/pipe_target_key.sh \"${target_key}\""
+        tmux bind-key -T easy-motion-target "${tmux_key}" run-shell -b "${SCRIPTS_DIR}/pipe_target_key.sh \"${server_pid}\" \"${target_key}\""
     done < <(echo -n "${EASY_MOTION_TARGET_KEYS}")
-    tmux bind-key -T easy-motion-target "Escape" run-shell -b "${SCRIPTS_DIR}/pipe_target_key.sh 'esc'"
+    tmux bind-key -T easy-motion-target "Escape" run-shell -b "${SCRIPTS_DIR}/pipe_target_key.sh \"${server_pid}\" 'esc'"
 }
 
 main() {
+    local server_pid
+    server_pid="$(get_tmux_server_pid)"
+
     check_version && \
     read_options && \
-    create_target_key_pipe && \
-    setup_bindings
+    create_target_key_pipe "${server_pid}" && \
+    setup_bindings "${server_pid}"
 }
 
 main

--- a/scripts/common_variables.sh
+++ b/scripts/common_variables.sh
@@ -3,5 +3,4 @@
 if [[ -z "${TMPDIR}" ]]; then
     TMPDIR="$(dirname "$(mktemp "tmp.XXXXXXXXXX" -ut)")"
 fi
-TARGET_KEY_PIPE_TMP_DIRECTORY="${TMPDIR}/tmux-easy-motion-target-key-pipe_$(id -un)"
 TARGET_KEY_PIPENAME="target_key.pipe"

--- a/scripts/easy_motion.sh
+++ b/scripts/easy_motion.sh
@@ -70,14 +70,17 @@ easy_motion_toggle_pane() {
 }
 
 easy_motion() {
-    local motion motion_argument ready_command jump_command jump_cursor_position
+    local server_pid motion motion_argument target_key_pipe_tmp_directory ready_command jump_command
+    local jump_cursor_position
 
-    motion="$1"
-    motion_argument="$2"
+    server_pid="$1"
+    motion="$2"
+    motion_argument="$3"
     # Undo escaping of motion arguments
     if [[ "${motion_argument:0:1}" == "\\" ]]; then
         motion_argument="${motion_argument:1}"
     fi
+    target_key_pipe_tmp_directory=$(get_target_key_pipe_tmp_directory "${server_pid}")
     pane_exec "${EASY_MOTION_PANE_ID}" \
               "${SCRIPTS_DIR}/easy_motion.py" \
               "${EASY_MOTION_DIM_STYLE}" \
@@ -91,7 +94,7 @@ easy_motion() {
               "${EASY_MOTION_PANE_SIZE}" \
               "${CAPTURE_TMP_DIRECTORY}/${CAPTURE_PANE_FILENAME}" \
               "${CAPTURE_TMP_DIRECTORY}/${JUMP_COMMAND_PIPENAME}" \
-              "${TARGET_KEY_PIPE_TMP_DIRECTORY}/${TARGET_KEY_PIPENAME}" && \
+              "${target_key_pipe_tmp_directory}/${TARGET_KEY_PIPENAME}" && \
 
     {
         read -r ready_command && \

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,4 +1,21 @@
 # shellcheck shell=bash
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${CURRENT_DIR}"
+
+# shellcheck source=./common_variables.sh
+source "${SCRIPTS_DIR}/common_variables.sh"
+
+get_target_key_pipe_tmp_directory() {
+    local server_pid
+
+    server_pid="$1"
+
+    echo "${TMPDIR}/tmux-easy-motion-target-key-pipe_$(id -un)_${server_pid}"
+}
+
+get_tmux_server_pid() {
+    [[ "${TMUX}" =~ .*,(.*),.* ]] && echo "${BASH_REMATCH[1]}"
+}
 
 escape_double_quotes() {
     local unescaped_string


### PR DESCRIPTION
It's possible to run multiple tmux servers. When that's happening, each server needs to have a separate pipe.  Use the server name in the path to the pipe directory to discriminate between the servers.